### PR TITLE
Eager load JSON files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,30 +46,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.4.tgz",
-      "integrity": "sha512-CHIGpJcUQ5lU9KrPHTjBMhVwQG6CQjxfg36fGXl3qk/Gik1WwWachaXFuo0uCWJT/mStOKtcbFJCaVLihC1CMw==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.1.tgz",
+      "integrity": "sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.19.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.3.tgz",
-      "integrity": "sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.2.tgz",
+      "integrity": "sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.3",
-        "@babel/helper-compilation-targets": "^7.19.3",
-        "@babel/helper-module-transforms": "^7.19.0",
-        "@babel/helpers": "^7.19.0",
-        "@babel/parser": "^7.19.3",
+        "@babel/generator": "^7.20.2",
+        "@babel/helper-compilation-targets": "^7.20.0",
+        "@babel/helper-module-transforms": "^7.20.2",
+        "@babel/helpers": "^7.20.1",
+        "@babel/parser": "^7.20.2",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.3",
-        "@babel/types": "^7.19.3",
+        "@babel/traverse": "^7.20.1",
+        "@babel/types": "^7.20.2",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -85,12 +85,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.19.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.5.tgz",
-      "integrity": "sha512-DxbNz9Lz4aMZ99qPpO1raTbcrI1ZeYh+9NR9qhfkQIbFtVEqotHojEBxHzmxhVONkGt6VyrqVQcgpefMy9pqcg==",
+      "version": "7.20.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
+      "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.19.4",
+        "@babel/types": "^7.20.2",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -113,12 +113,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.19.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.3.tgz",
-      "integrity": "sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
+      "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.19.3",
+        "@babel/compat-data": "^7.20.0",
         "@babel/helper-validator-option": "^7.18.6",
         "browserslist": "^4.21.3",
         "semver": "^6.3.0"
@@ -177,40 +177,40 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
-      "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
+      "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-simple-access": "^7.18.6",
+        "@babel/helper-simple-access": "^7.20.2",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.19.1",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.0",
-        "@babel/types": "^7.19.0"
+        "@babel/traverse": "^7.20.1",
+        "@babel/types": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz",
-      "integrity": "sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+      "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.19.4"
+        "@babel/types": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -256,14 +256,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.4.tgz",
-      "integrity": "sha512-G+z3aOx2nfDHwX/kyVii5fJq+bgscg89/dJNWpYeKeBv3v9xX8EIabmx1k6u9LS04H7nROFVRVK+e3k0VHp+sw==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.1.tgz",
+      "integrity": "sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.4",
-        "@babel/types": "^7.19.4"
+        "@babel/traverse": "^7.20.1",
+        "@babel/types": "^7.20.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -355,9 +355,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.4.tgz",
-      "integrity": "sha512-qpVT7gtuOLjWeDTKLkJ6sryqLliBaFpAtGeqw5cs5giLldvh+Ch0plqnUMKoVAUS6ZEueQQiZV+p5pxtPitEsA==",
+      "version": "7.20.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
+      "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -529,12 +529,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.18.6.tgz",
-      "integrity": "sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.20.0.tgz",
+      "integrity": "sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.19.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -558,19 +558,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.4.tgz",
-      "integrity": "sha512-w3K1i+V5u2aJUOXBFFC5pveFLmtq1s3qcdDNC2qRI6WPBQIDaKFqXxDEqDO/h1dQ3HjsZoZMyIy6jGLq0xtw+g==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
+      "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.4",
+        "@babel/generator": "^7.20.1",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.19.4",
-        "@babel/types": "^7.19.4",
+        "@babel/parser": "^7.20.1",
+        "@babel/types": "^7.20.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -579,9 +579,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.4.tgz",
-      "integrity": "sha512-M5LK7nAeS6+9j7hAq+b3fQs+pNfUtTGq+yFFfHnauFA8zQtLRfmuipmsKDKKLuyG+wC8ABW43A153YNawNTEtw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
+      "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -4458,27 +4458,27 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.4.tgz",
-      "integrity": "sha512-CHIGpJcUQ5lU9KrPHTjBMhVwQG6CQjxfg36fGXl3qk/Gik1WwWachaXFuo0uCWJT/mStOKtcbFJCaVLihC1CMw==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.1.tgz",
+      "integrity": "sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.19.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.3.tgz",
-      "integrity": "sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.2.tgz",
+      "integrity": "sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.3",
-        "@babel/helper-compilation-targets": "^7.19.3",
-        "@babel/helper-module-transforms": "^7.19.0",
-        "@babel/helpers": "^7.19.0",
-        "@babel/parser": "^7.19.3",
+        "@babel/generator": "^7.20.2",
+        "@babel/helper-compilation-targets": "^7.20.0",
+        "@babel/helper-module-transforms": "^7.20.2",
+        "@babel/helpers": "^7.20.1",
+        "@babel/parser": "^7.20.2",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.3",
-        "@babel/types": "^7.19.3",
+        "@babel/traverse": "^7.20.1",
+        "@babel/types": "^7.20.2",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -4487,12 +4487,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.19.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.5.tgz",
-      "integrity": "sha512-DxbNz9Lz4aMZ99qPpO1raTbcrI1ZeYh+9NR9qhfkQIbFtVEqotHojEBxHzmxhVONkGt6VyrqVQcgpefMy9pqcg==",
+      "version": "7.20.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
+      "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.19.4",
+        "@babel/types": "^7.20.2",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -4511,12 +4511,12 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.19.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.3.tgz",
-      "integrity": "sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
+      "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.19.3",
+        "@babel/compat-data": "^7.20.0",
         "@babel/helper-validator-option": "^7.18.6",
         "browserslist": "^4.21.3",
         "semver": "^6.3.0"
@@ -4557,34 +4557,34 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
-      "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
+      "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
       "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-simple-access": "^7.18.6",
+        "@babel/helper-simple-access": "^7.20.2",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.19.1",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.0",
-        "@babel/types": "^7.19.0"
+        "@babel/traverse": "^7.20.1",
+        "@babel/types": "^7.20.2"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
       "dev": true
     },
     "@babel/helper-simple-access": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz",
-      "integrity": "sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+      "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.19.4"
+        "@babel/types": "^7.20.2"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -4615,14 +4615,14 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.4.tgz",
-      "integrity": "sha512-G+z3aOx2nfDHwX/kyVii5fJq+bgscg89/dJNWpYeKeBv3v9xX8EIabmx1k6u9LS04H7nROFVRVK+e3k0VHp+sw==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.1.tgz",
+      "integrity": "sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.4",
-        "@babel/types": "^7.19.4"
+        "@babel/traverse": "^7.20.1",
+        "@babel/types": "^7.20.0"
       }
     },
     "@babel/highlight": {
@@ -4695,9 +4695,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.4.tgz",
-      "integrity": "sha512-qpVT7gtuOLjWeDTKLkJ6sryqLliBaFpAtGeqw5cs5giLldvh+Ch0plqnUMKoVAUS6ZEueQQiZV+p5pxtPitEsA==",
+      "version": "7.20.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
+      "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -4818,12 +4818,12 @@
       }
     },
     "@babel/plugin-syntax-typescript": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.18.6.tgz",
-      "integrity": "sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.20.0.tgz",
+      "integrity": "sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.19.0"
       }
     },
     "@babel/template": {
@@ -4838,27 +4838,27 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.4.tgz",
-      "integrity": "sha512-w3K1i+V5u2aJUOXBFFC5pveFLmtq1s3qcdDNC2qRI6WPBQIDaKFqXxDEqDO/h1dQ3HjsZoZMyIy6jGLq0xtw+g==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
+      "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.4",
+        "@babel/generator": "^7.20.1",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.19.4",
-        "@babel/types": "^7.19.4",
+        "@babel/parser": "^7.20.1",
+        "@babel/types": "^7.20.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.4.tgz",
-      "integrity": "sha512-M5LK7nAeS6+9j7hAq+b3fQs+pNfUtTGq+yFFfHnauFA8zQtLRfmuipmsKDKKLuyG+wC8ABW43A153YNawNTEtw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
+      "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.19.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moonwell-fi/moonwell.js",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "The moonwell.js library is a suite of tools to query and interact with the Moonwell protocol.",
   "main": "dist/index.js",
   "files": [
@@ -8,7 +8,7 @@
     "src"
   ],
   "scripts": {
-    "build": "tsc && cp -r src/deploy-artifacts dist/deploy-artifacts",
+    "build": "tsc",
     "test": "jest"
   },
   "author": "",

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -3,74 +3,56 @@ import { DeployArtifact } from './types'
 
 /** A contract in the Moonwell ecosystem. */
 export class MoonwellContract {
+  public contract: ethers.Contract
+
   /**
    * @param address The address of the contract.
-   * @param artifactPath A path to the artifact to load.
+   * @param artifact The artifact to use.
    * @param signerOrProvider An optional signer that will be attached to all contract instances.
    */
   constructor(
       readonly address: string,
-      readonly artifactPath: string,
+      readonly artifact: DeployArtifact,
       readonly signerOrProvider?: ethers.Signer | ethers.providers.Provider
-  ) {}
+  ) {
+    this.artifact = artifact
 
-  /** 
-   * Get an ethers Contract instance representing the contract.
-   * 
-   * @param signerOrProvider An optional signer or provider that will be attached to the contract.
-   */
-  public getContract(signerOrProvider?: ethers.Signer | ethers.providers.Provider): ethers.Contract {
-    return new ethers.Contract(
+    console.log({artifact})
+
+    this.contract = new ethers.Contract(
         this.address,
-        this.getContractArtifact().abi,
+        this.artifact.abi,
         signerOrProvider || this.signerOrProvider
     )
-  }
-
-  /**
-   * Return the deploy artifact that backs the contract.   
-   */
-  public getContractArtifact(): DeployArtifact {
-    return require(this.artifactPath)
   }
 }
 
 /** A contract with a proxy in the Moonwell ecosystem. */
 export class MoonwellContractWithProxy extends MoonwellContract {
+  public proxyContract: ethers.Contract
+
   /**
    * @param proxyAddress The address of the contract.
-   * @param implementationArtifactPath A path to the artifact to load when calls are passing through the proxy.
-   * @param proxyArtifactPath A path to the artifact to load when working with tthe proxy directly.
+   * @param implementationArtifact A path to the artifact to load when calls are passing through the proxy.
+   * @param proxyArtifact A path to the artifact to load when working with tthe proxy directly.
    * @param signerOrProvider An optional signer that will be attached to all contract instances.
    */
   constructor(
       readonly proxyAddress: string,
-      readonly implementationArtifactPath: string,
-      readonly proxyArtifactPath: string,
-      signerOrProvider?,
+      readonly implementationArtifact: DeployArtifact,
+      readonly proxyArtifact: DeployArtifact,
+      signerOrProvider?: ethers.Signer | ethers.providers.Provider,
   ) {
     // Ensure `getContract` will return a proxy target with an implementation ABI
-    super(proxyAddress, implementationArtifactPath, signerOrProvider)
-  }
+    super(proxyAddress, implementationArtifact, signerOrProvider)
 
-  /** 
-   * Get an ethers Contract instance representing the proxy contract.
-   * 
-   * @param signerOrProvider An optional signer or provider that will be attached to the contract.
-   */
-  public getProxyContract(signerOrProvider?: ethers.Signer | ethers.providers.Provider): ethers.Contract {
-    return new ethers.Contract(
+    this.proxyArtifact = proxyArtifact
+
+    this.proxyContract = new ethers.Contract(
         this.proxyAddress,
-        this.getProxyArtifact().abi,
+        this.proxyArtifact.abi,
         signerOrProvider || this.signerOrProvider
     )
-  }
-
-  /**
-   * Return the deploy artifact that backs the proxy contract.   
-   */
-  public getProxyArtifact(): DeployArtifact {
-    return require(this.proxyArtifactPath)
   }
 }
 

--- a/src/deploy-artifacts/InterestRateModel.json
+++ b/src/deploy-artifacts/InterestRateModel.json
@@ -1,0 +1,93 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "InterestRateModel",
+  "sourceName": "moonwell-contracts-private/contracts/core/InterestRateModel.sol",
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "cash",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "borrows",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reserves",
+          "type": "uint256"
+        }
+      ],
+      "name": "getBorrowRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "cash",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "borrows",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reserves",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "reserveFactorMantissa",
+          "type": "uint256"
+        }
+      ],
+      "name": "getSupplyRate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "isInterestRateModel",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x",
+  "deployedBytecode": "0x",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/src/deploy-artifacts/SolarbeamRewarder.json
+++ b/src/deploy-artifacts/SolarbeamRewarder.json
@@ -1,0 +1,632 @@
+{
+  "_format": "",
+  "contractName": "",
+  "sourceName": "",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "contract IBoringERC20",
+          "name": "_rewardToken",
+          "type": "address"
+        },
+        {
+          "internalType": "contract ISolarDistributorV2",
+          "name": "_distributorV2",
+          "type": "address"
+        },
+        {
+          "internalType": "bool",
+          "name": "_isNative",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "pid",
+          "type": "uint256"
+        }
+      ],
+      "name": "AddPool",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "pid",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "phase",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "endTimestamp",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "rewardPerSec",
+          "type": "uint256"
+        }
+      ],
+      "name": "AddRewardInfo",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "OnReward",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "oldRate",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newRate",
+          "type": "uint256"
+        }
+      ],
+      "name": "RewardRateUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "pid",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "lastRewardTimestamp",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "lpSupply",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "accTokenPerShare",
+          "type": "uint256"
+        }
+      ],
+      "name": "UpdatePool",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_from",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_to",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_endTimestamp",
+          "type": "uint256"
+        }
+      ],
+      "name": "_getTimeElapsed",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "pid",
+          "type": "uint256"
+        }
+      ],
+      "name": "_updatePool",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "accTokenPerShare",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "startTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lastRewardTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "totalRewards",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct ComplexRewarderPerSecV3.PoolInfo",
+          "name": "pool",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_startTimestamp",
+          "type": "uint256"
+        }
+      ],
+      "name": "add",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_endTimestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_rewardPerSec",
+          "type": "uint256"
+        }
+      ],
+      "name": "addRewardInfo",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        }
+      ],
+      "name": "currentEndTimestamp",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "distributorV2",
+      "outputs": [
+        {
+          "internalType": "contract ISolarDistributorV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_beneficiary",
+          "type": "address"
+        }
+      ],
+      "name": "emergencyRewardWithdraw",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "isNative",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "massUpdatePools",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_user",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "onSolarReward",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_user",
+          "type": "address"
+        }
+      ],
+      "name": "pendingTokens",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "poolIds",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "poolInfo",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "accTokenPerShare",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "startTimestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "lastRewardTimestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "totalRewards",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "poolRewardInfo",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "startTimestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "endTimestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "rewardPerSec",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        }
+      ],
+      "name": "poolRewardsPerSec",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "rewardInfoLimit",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "rewardToken",
+      "outputs": [
+        {
+          "internalType": "contract IBoringERC20",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        }
+      ],
+      "name": "updatePool",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "accTokenPerShare",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "startTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lastRewardTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "totalRewards",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct ComplexRewarderPerSecV3.PoolInfo",
+          "name": "pool",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "userInfo",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "rewardDebt",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "bytecode": "",
+  "deployedBytecode": "",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/src/deploy-artifacts/StellaswapRewarder.json
+++ b/src/deploy-artifacts/StellaswapRewarder.json
@@ -1,0 +1,708 @@
+{
+  "_format": "",
+  "contractName": "",
+  "sourceName": "",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "contract IBoringERC20",
+          "name": "_rewardToken",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IStellaDistributorV2",
+          "name": "_distributorV2",
+          "type": "address"
+        },
+        {
+          "internalType": "bool",
+          "name": "_isNative",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "pid",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "allocPoint",
+          "type": "uint256"
+        }
+      ],
+      "name": "AddPool",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "pid",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "phase",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "endTimestamp",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "rewardPerSec",
+          "type": "uint256"
+        }
+      ],
+      "name": "AddRewardInfo",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "OnReward",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "oldRate",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newRate",
+          "type": "uint256"
+        }
+      ],
+      "name": "RewardRateUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "pid",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "allocPoint",
+          "type": "uint256"
+        }
+      ],
+      "name": "SetPool",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "pid",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "lastRewardTimestamp",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "lpSupply",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "accTokenPerShare",
+          "type": "uint256"
+        }
+      ],
+      "name": "UpdatePool",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_from",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_to",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_endTimestamp",
+          "type": "uint256"
+        }
+      ],
+      "name": "_getTimeElapsed",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "pid",
+          "type": "uint256"
+        }
+      ],
+      "name": "_updatePool",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "accTokenPerShare",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "startTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lastRewardTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "allocPoint",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "totalRewards",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct ComplexRewarderPerSecV2.PoolInfo",
+          "name": "pool",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_allocPoint",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_startTimestamp",
+          "type": "uint256"
+        }
+      ],
+      "name": "add",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_endTimestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_rewardPerSec",
+          "type": "uint256"
+        }
+      ],
+      "name": "addRewardInfo",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        }
+      ],
+      "name": "currentEndTimestamp",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "distributorV2",
+      "outputs": [
+        {
+          "internalType": "contract IStellaDistributorV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_beneficiary",
+          "type": "address"
+        }
+      ],
+      "name": "emergencyRewardWithdraw",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "inCaseTokensGetStuck",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "isNative",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "massUpdatePools",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_user",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "onStellaReward",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_user",
+          "type": "address"
+        }
+      ],
+      "name": "pendingTokens",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "poolIds",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "poolInfo",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "accTokenPerShare",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "startTimestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "lastRewardTimestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "allocPoint",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "totalRewards",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "poolRewardInfo",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "startTimestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "endTimestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "rewardPerSec",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        }
+      ],
+      "name": "poolRewardsPerSec",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "rewardInfoLimit",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "rewardToken",
+      "outputs": [
+        {
+          "internalType": "contract IBoringERC20",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalAllocPoint",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_pid",
+          "type": "uint256"
+        }
+      ],
+      "name": "updatePool",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "accTokenPerShare",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "startTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "lastRewardTimestamp",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "allocPoint",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "totalRewards",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct ComplexRewarderPerSecV2.PoolInfo",
+          "name": "pool",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "userInfo",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "rewardDebt",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "bytecode": "",
+  "deployedBytecode": "",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/src/deploy-artifacts/TransparentProxy.json
+++ b/src/deploy-artifacts/TransparentProxy.json
@@ -1,0 +1,10 @@
+{
+    "_format": "",
+    "contractName": "",
+    "sourceName": "",
+    "abi": [{"inputs":[{"internalType":"address","name":"_logic","type":"address"},{"internalType":"address","name":"admin_","type":"address"},{"internalType":"bytes","name":"_data","type":"bytes"}],"stateMutability":"payable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"address","name":"previousAdmin","type":"address"},{"indexed":false,"internalType":"address","name":"newAdmin","type":"address"}],"name":"AdminChanged","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"beacon","type":"address"}],"name":"BeaconUpgraded","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"implementation","type":"address"}],"name":"Upgraded","type":"event"},{"stateMutability":"payable","type":"fallback"},{"inputs":[],"name":"admin","outputs":[{"internalType":"address","name":"admin_","type":"address"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"newAdmin","type":"address"}],"name":"changeAdmin","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"implementation","outputs":[{"internalType":"address","name":"implementation_","type":"address"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"newImplementation","type":"address"}],"name":"upgradeTo","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"newImplementation","type":"address"},{"internalType":"bytes","name":"data","type":"bytes"}],"name":"upgradeToAndCall","outputs":[],"stateMutability":"payable","type":"function"},{"stateMutability":"payable","type":"receive"}],
+    "bytecode": "",
+    "deployedBytecode": "",
+    "linkReferences": {},
+    "deployedLinkReferences": {}
+}

--- a/src/environments/moonbase.ts
+++ b/src/environments/moonbase.ts
@@ -3,65 +3,77 @@ import BigNumber from "bignumber.js";
 import { ContractBundle } from "../types";
 import { MoonwellContract, MoonwellContractWithProxy } from '../contracts'
 
+import TokenSaleDistributor from '../deploy-artifacts/TokenSaleDistributor.json'
+import TokenSaleDistributorProxy from '../deploy-artifacts/TokenSaleDistributorProxy.json'
+import MoonwellGovernorArtemis from '../deploy-artifacts/MoonwellGovernorArtemis.json'
+import Comptroller from '../deploy-artifacts/Comptroller.json'
+import Unitroller from '../deploy-artifacts/Unitroller.json'
+import Well from '../deploy-artifacts/Well.json'
+import Maximillion from '../deploy-artifacts/Maximillion.json'
+import ChainlinkOracle from '../deploy-artifacts/ChainlinkOracle.json'
+import StakedWell from '../deploy-artifacts/StakedWell.json'
+import TransparentProxy from '../deploy-artifacts/TransparentProxy.json'
+import Timelock from '../deploy-artifacts/Timelock.json'
+import InterestRateModel from '../deploy-artifacts/InterestRateModel.json'
+import MErc20Delegator from '../deploy-artifacts/MErc20Delegator.json'
+import SolarbeamRewarder from '../deploy-artifacts/SolarbeamRewarder.json'
+
 export const contracts: ContractBundle = {
     CLAIMS: new MoonwellContractWithProxy(
         '0xe7e6cdb90797f053229c0a81c3de9dc8110188b5',
-        './deploy-artifacts/TokenSaleDistributor.json',
-        './deploy-artifacts/TokenSaleDistributorProxy.json',
+        TokenSaleDistributor,
+        TokenSaleDistributorProxy,
     ),
     GOVERNOR: new MoonwellContract(
         '0x1eA239b116b911374BA144EFb5cA077d3A224fE9',
-        './deploy-artifacts/MoonwellGovernorArtemis.json',
+        MoonwellGovernorArtemis,
     ),
 
     COMPTROLLER: new MoonwellContractWithProxy(
         '0x4524e0Dfa042188B1F9f804642456277dbDBE253', 
-        './deploy-artifacts/Comptroller.json',
-        './deploy-artifacts/Unitroller.json',
+        Comptroller,
+        Unitroller,
     ),
-
 
     GOV_TOKEN:  new MoonwellContract(
         '0x6efCf8fB404AC6DE593cE461877A634d067C942E', 
-        './deploy-artifacts/Well.json'
+        Well
     ),
 
-
     MAXIMILLION: new MoonwellContract(
-        '0xa2A09f11208327e69Ede9c2C6eE95282a13527AF', 
-        './deploy-artifacts/Maximillion.json'
+        '0xa2A09f11208327e69Ede9c2C6eE95282a13527AF',
+        Maximillion
     ),
 
     ORACLE: new MoonwellContract(
-        '0x0A3F1AA8bc5C51bbD313e63644f2297aA170FF87', 
-        './deploy-artifacts/ChainlinkOracle.json'
+        '0x0A3F1AA8bc5C51bbD313e63644f2297aA170FF87',
+        ChainlinkOracle
     ),
-
 
     SAFETY_MODULE: new MoonwellContractWithProxy(
         '0x11fD9c97B0B8F50f6EB0e68342e3de8F76dd45fc', 
-        './deploy-artifacts/StakedWell.json',
-        './deploy-artifacts/TransparentProxy.json',
+        StakedWell,
+        TransparentProxy
     ),
 
     TIMELOCK: new MoonwellContract(
         '0xE2270EEf667A66AF330f8411C17E79BdA2FC3595', 
-        './deploy-artifacts/Timelock.json',
+        Timelock
     ),
 
     INTEREST_RATE_MODEL: new MoonwellContract(
-        '0x4BABE1d4f89CbDdA49f0402B2C39d0c1923BF4A7', 
-        './deploy-artifacts/StakedWell.json',
+        '0x4BABE1d4f89CbDdA49f0402B2C39d0c1923BF4A7',
+        InterestRateModel,
     ),
 
     MERC_20_IMPL: new MoonwellContract(
-        '0x83C5dE4dDc7bE93907Cb599aCFd2db47838e00df', 
-        './deploy-artifacts/MErc20Delegator.json',
+        '0x83C5dE4dDc7bE93907Cb599aCFd2db47838e00df',
+        MErc20Delegator,
     ),
 
     DEX_REWARDER: new MoonwellContract(
         '0xC58Fe6C98076175FEBebdc73485576eA1c3750BF',
-        './deploy-artifacts/solarbeamRewarder.json'
+        SolarbeamRewarder
     ),
 
     MARKETS: {

--- a/src/environments/moonbeam.ts
+++ b/src/environments/moonbeam.ts
@@ -3,63 +3,78 @@ import BigNumber from "bignumber.js";
 import { ContractBundle } from "../types";
 import { MoonwellContract, MoonwellContractWithProxy } from '../contracts'
 
+import TokenSaleDistributor from '../deploy-artifacts/TokenSaleDistributor.json'
+import TokenSaleDistributorProxy from '../deploy-artifacts/TokenSaleDistributorProxy.json'
+import MoonwellGovernorArtemis from '../deploy-artifacts/MoonwellGovernorArtemis.json'
+import Comptroller from '../deploy-artifacts/Comptroller.json'
+import Unitroller from '../deploy-artifacts/Unitroller.json'
+import Well from '../deploy-artifacts/Well.json'
+import Maximillion from '../deploy-artifacts/Maximillion.json'
+import ChainlinkOracle from '../deploy-artifacts/ChainlinkOracle.json'
+import StakedWell from '../deploy-artifacts/StakedWell.json'
+import TransparentProxy from '../deploy-artifacts/TransparentProxy.json'
+import Timelock from '../deploy-artifacts/Timelock.json'
+import InterestRateModel from '../deploy-artifacts/InterestRateModel.json'
+import MErc20Delegator from '../deploy-artifacts/MErc20Delegator.json'
+import StellaswapRewarder from '../deploy-artifacts/stellaswapRewarder.json'
+
 export const contracts: ContractBundle = {
     CLAIMS: new MoonwellContractWithProxy(
         '0x933fCDf708481c57E9FD82f6BAA084f42e98B60e',
-        './deploy-artifacts/TokenSaleDistributor.json',
-        './deploy-artifacts/TokenSaleDistributorProxy.json',
+        TokenSaleDistributor,
+        TokenSaleDistributorProxy,
     ),
 
     GOVERNOR: new MoonwellContract(
         '0xfc4DFB17101A12C5CEc5eeDd8E92B5b16557666d',
-        './deploy-artifacts/MoonwellGovernorArtemis.json',
+        MoonwellGovernorArtemis,
     ),
 
     COMPTROLLER: new MoonwellContractWithProxy(
         '0x8E00D5e02E65A19337Cdba98bbA9F84d4186a180', 
-        './deploy-artifacts/Comptroller.json',
-        './deploy-artifacts/Unitroller.json',
+        Comptroller,
+        Unitroller,
     ),
 
     GOV_TOKEN:  new MoonwellContract(
-        '0x511aB53F793683763E5a8829738301368a2411E3', 
-        './deploy-artifacts/Well.json'
+        '0x511aB53F793683763E5a8829738301368a2411E3',
+        Well
     ),
 
     MAXIMILLION: new MoonwellContract(
         '0xe5Ef9310cC7E3437bAD83466675f24FD62A380c3', 
-        './deploy-artifacts/Maximillion.json'
+        Maximillion
     ),
 
     ORACLE: new MoonwellContract(
         '0xED301cd3EB27217BDB05C4E9B820a8A3c8B665f9', 
-        './deploy-artifacts/ChainlinkOracle.json'
+        ChainlinkOracle
     ),
 
     SAFETY_MODULE: new MoonwellContractWithProxy(
         '0x8568A675384d761f36eC269D695d6Ce4423cfaB1', 
-        './deploy-artifacts/StakedWell.json',
-        './deploy-artifacts/TransparentProxy.json',
+        StakedWell,
+        TransparentProxy,
     ),
 
     TIMELOCK: new MoonwellContract(
         '0x3a9249d70dCb4A4E9ef4f3AF99a3A130452ec19B', 
-        './deploy-artifacts/Timelock.json',
+        Timelock,
     ),
 
     INTEREST_RATE_MODEL: new MoonwellContract(
         '0x1Ce7e4928943d6A4820375eBe737204dc1E73755', 
-        './deploy-artifacts/StakedWell.json',
+        InterestRateModel,
     ),
 
     MERC_20_IMPL: new MoonwellContract(
         '0x948CCfff51F894DBA5C250aa2844d58E169f8aD9', 
-        './deploy-artifacts/MErc20Delegator.json',
+        MErc20Delegator,
     ),
 
     DEX_REWARDER: new MoonwellContract(
         '0xcD04D2340c1dD9B3dB2C5c53c8B8bAa57b2654Be',
-        './deploy-artifacts/stellaswapRewarder.json'
+        StellaswapRewarder
     ),
 
     MARKETS: {

--- a/src/environments/moonriver.ts
+++ b/src/environments/moonriver.ts
@@ -3,65 +3,78 @@ import BigNumber from "bignumber.js";
 import { ContractBundle } from "../types";
 import { MoonwellContract, MoonwellContractWithProxy } from '../contracts'
 
+import TokenSaleDistributor from '../deploy-artifacts/TokenSaleDistributor.json'
+import TokenSaleDistributorProxy from '../deploy-artifacts/TokenSaleDistributorProxy.json'
+import MoonwellGovernorApollo from '../deploy-artifacts/MoonwellGovernorApollo.json'
+import Comptroller from '../deploy-artifacts/Comptroller.json'
+import Unitroller from '../deploy-artifacts/Unitroller.json'
+import Well from '../deploy-artifacts/Well.json'
+import Maximillion from '../deploy-artifacts/Maximillion.json'
+import ChainlinkOracle from '../deploy-artifacts/ChainlinkOracle.json'
+import StakedWell from '../deploy-artifacts/StakedWell.json'
+import TransparentProxy from '../deploy-artifacts/TransparentProxy.json'
+import Timelock from '../deploy-artifacts/Timelock.json'
+import InterestRateModel from '../deploy-artifacts/InterestRateModel.json'
+import MErc20Delegator from '../deploy-artifacts/MErc20Delegator.json'
+import SolarbeamRewarder from '../deploy-artifacts/SolarbeamRewarder.json'
+
 export const contracts: ContractBundle = {
     CLAIMS: new MoonwellContractWithProxy(
         '0x8568A675384d761f36eC269D695d6Ce4423cfaB1',
-        './deploy-artifacts/TokenSaleDistributor.json',
-        './deploy-artifacts/TokenSaleDistributorProxy.json',
+        TokenSaleDistributor,
+        TokenSaleDistributorProxy,
     ),
     GOVERNOR: new MoonwellContract(
         '0x2BE2e230e89c59c8E20E633C524AD2De246e7370',
-        './deploy-artifacts/MoonwellGovernorApollo.json',
+        MoonwellGovernorApollo,
     ),
 
     COMPTROLLER: new MoonwellContractWithProxy(
         '0x0b7a0EAA884849c6Af7a129e899536dDDcA4905E',
-        './deploy-artifacts/Comptroller.json',
-        './deploy-artifacts/Unitroller.json',
+        Comptroller,
+        Unitroller,
     ),
-
 
     GOV_TOKEN:  new MoonwellContract(
         '0xBb8d88bcD9749636BC4D2bE22aaC4Bb3B01A58F1',
-        './deploy-artifacts/Well.json'
+        Well,
     ),
-
 
     MAXIMILLION: new MoonwellContract(
         '0x1650C0AD9483158f9e240fd58d0E173807A80CcC',
-        './deploy-artifacts/Maximillion.json'
+        Maximillion,
     ),
 
     ORACLE: new MoonwellContract(
         '0x892bE716Dcf0A6199677F355f45ba8CC123BAF60',
-        './deploy-artifacts/ChainlinkOracle.json'
+        ChainlinkOracle,
     ),
 
 
     SAFETY_MODULE: new MoonwellContractWithProxy(
         '0xCd76e63f3AbFA864c53b4B98F57c1aA6539FDa3a',
-        './deploy-artifacts/StakedWell.json',
-        './deploy-artifacts/TransparentProxy.json',
+        StakedWell,
+        TransparentProxy,
     ),
 
     TIMELOCK: new MoonwellContract(
         '0x04e6322D196E0E4cCBb2610dd8B8f2871E160bd7',
-        './deploy-artifacts/Timelock.json',
+        Timelock,
     ),
 
     INTEREST_RATE_MODEL: new MoonwellContract(
         '0xC862A3af64a8d3C146E6c505a18c2B6c6a6601bf',
-        './deploy-artifacts/StakedWell.json',
+        InterestRateModel,
     ),
 
     MERC_20_IMPL: new MoonwellContract(
         '0x45d17FE87e65064b2e85F91A9FF3aD0C7B6Cf75d',
-        './deploy-artifacts/MErc20Delegator.json',
+        MErc20Delegator,
     ),
 
     DEX_REWARDER: new MoonwellContract(
         '0x79a1a71786a325db7Fe70bbF080a1ee046F53c74',
-        './deploy-artifacts/solarbeamRewarder.json'
+        SolarbeamRewarder,
     ),
 
     MARKETS: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import {  ethers } from "ethers";
+import { ethers } from "ethers";
 import { MoonwellContract, MoonwellContractWithProxy } from "./contracts";
 
 export type StringOrNull = string | null

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -21,11 +21,11 @@ test('environments & contract loading', () => {
     for ([contractName, contractObject] of Object.entries(contracts)){
       if (contractName !== 'MARKETS'){
         // Ensure all contracts load successfully
-        const artifact = contractObject.getContractArtifact()
+        const artifact = contractObject.artifact
         expect(artifact.abi).toBeDefined()
         expect(artifact.abi.length).toBeGreaterThan(0)
 
-        const contract = contractObject.getContract()
+        const contract = contractObject.contract
         expect(contract).toBeInstanceOf(ethers.Contract)
       }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
     "outDir": "dist",
     "lib": ["esnext", "dom"],
     "sourceMap": true,
-    "declaration": true
+    "declaration": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
This allows for better compatibility between browser consumers and node consumers of the moonwell.js library. 

As part of loading an environment's contracts, we just eager load and initialize all contracts since the browser literally can't `require()` random files from a project without introducing webpack to do things like emulate a filesystem and bundle things, and if we change things to eagerly load all that goes away. 

Since this does break the current interface a bit (moving from `getContract()` to simply `contract`, and `getArtifact()` to `artifact`) I'm bumping things to 0.2.0. 

LMK if you have questions/comments! 